### PR TITLE
Add analysis script and generated pharma_report.txt

### DIFF
--- a/pharma_analysis.py
+++ b/pharma_analysis.py
@@ -1,0 +1,29 @@
+sales_data = [
+    {"product": "PainRelief", "quantity": 120, "price": 8.50},
+    {"product": "PainRelief", "quantity": 80, "price": 8.50},
+    {"product": "AllergyEase", "quantity": 60, "price": 12.00},
+    {"product": "AllergyEase", "quantity": 40, "price": 12.00},
+    {"product": "CoughStop", "quantity": 150, "price": 6.75},
+]
+
+total_sales = {}
+
+for sale in sales_data:
+    product = sale["product"]
+    sale_total = sale["quantity"] * sale["price"]
+    if product not in total_sales:
+        total_sales[product] = 0
+    total_sales[product] += sale_total
+
+print("Total Sales by Product:")
+for product, total in total_sales.items():
+    print(f"- {product}: ${total:.2f}")
+
+print("Pharma data analysis completed successfully")
+
+with open("pharma_report.txt", "w") as report_file:
+    report_file.write("Pharma Sales Analysis Report\n")
+    report_file.write("Total Sales by Product:\n")
+    for product, total in total_sales.items():
+        report_file.write(f"- {product}: ${total:.2f}\n")
+    report_file.write("Analysis generated successfully\n")

--- a/pharma_report.txt
+++ b/pharma_report.txt
@@ -1,0 +1,6 @@
+Pharma Sales Analysis Report
+Total Sales by Product:
+- PainRelief: $1700.00
+- AllergyEase: $1200.00
+- CoughStop: $1012.50
+Analysis generated successfully


### PR DESCRIPTION
### Motivation
- Persist analysis output by saving computed totals to `pharma_report.txt` for later inspection.
- Present clear, human-readable per-product totals and a completion message so results are easy to verify.

### Description
- Add `pharma_analysis.py` which defines example `sales_data`, aggregates totals per product into `total_sales`, prints the totals, and writes the same content to `pharma_report.txt`.
- Add `pharma_report.txt` containing a report header, the per-product totals, and a final completion message.
- Implement the logic using basic Python constructs (`open`, loops, f-strings, and dictionaries) for readability and compatibility.

### Testing
- Ran `python /workspace/pharma-assignment-automation/pharma_analysis.py` and it printed the totals and completion message successfully.
- Verified the created `pharma_report.txt` contents with `nl -ba /workspace/pharma-assignment-automation/pharma_report.txt` which showed the header, totals, and completion message.
- Committed the report with `git -C /workspace/pharma-assignment-automation commit` successfully, and `git -C /workspace/pharma-assignment-automation push` failed due to no remote configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698326eee728832aaf6a277f0cf6c74b)